### PR TITLE
Add CRUD Functionality for GitHub Rulesets

### DIFF
--- a/changelog/11.fixed.md
+++ b/changelog/11.fixed.md
@@ -1,0 +1,1 @@
+Add CRUD funtionality for Github rulesets

--- a/src/saltext/github/modules/github.py
+++ b/src/saltext/github/modules/github.py
@@ -1882,8 +1882,6 @@ def _query(
 
         else:
             return result
-            # err = result.get("error")
-            # raise CommandExecutionError(f"GitHub Response Error: {err}")
 
         try:
             link_info = result.get("headers").get("Link").split(",")[0]

--- a/src/saltext/github/modules/github.py
+++ b/src/saltext/github/modules/github.py
@@ -2172,12 +2172,14 @@ def list_rulesets(profile="github", **kwargs):
 
     if not kwargs.get("per_page"):
         try:
-            per_page = _get_config_value(profile, "per_page")
+            kwargs["per_page"] = _get_config_value(profile, "per_page")
         except CommandExecutionError:
-            per_page = None
+            kwargs["per_page"] = None
 
     try:
-        ret = _query(profile, action, header_dict=params["header_dict"], per_page=per_page)
+        ret = _query(
+            profile, action, header_dict=params["header_dict"], per_page=kwargs["per_page"]
+        )
         if not ret.get("error"):
             if ret["dict"]:
                 return ret["dict"]

--- a/src/saltext/github/modules/github.py
+++ b/src/saltext/github/modules/github.py
@@ -2182,8 +2182,8 @@ def list_rulesets(profile="github", **kwargs):
         )
         if not ret.get("error"):
             if ret["dict"]:
-                return ret["dict"]
-            return None
+                return {"rulesets": ret["dict"]}
+            return {"rulesets": None}
         else:
             ret["comment"] = f"GitHub Response Status Code: {ret.get('error')}"
             ret["result"] = False

--- a/src/saltext/github/modules/github.py
+++ b/src/saltext/github/modules/github.py
@@ -2005,9 +2005,8 @@ def get_ruleset(profile="github", **kwargs):
         ret = _query(profile, action, header_dict=params["header_dict"])
         if not ret.get("error"):
             return ret["dict"]
-        else:
-            ret["comment"] = f"GitHub Response Status Code: {ret.get('error')}"
-            ret["result"] = False
+        ret["comment"] = f"GitHub Response Status Code: {ret.get('error')}"
+        ret["result"] = False
     except CommandExecutionError:
         ret = {}
         ret["result"] = False
@@ -2048,11 +2047,11 @@ def delete_ruleset(profile="github", **kwargs):
 
     try:
         ret = _query(profile, action, method="DELETE", header_dict=params["header_dict"])
-        if not ret.get("error"):
-            ret["comment"] = f"ruleset {params['ruleset_id']} successfully deleted"
-        else:
+        if ret.get("error"):
             ret["comment"] = f"GitHub Response Status Code: {ret.get('error')}"
             ret["result"] = False
+        else:
+            ret["comment"] = f"ruleset {params['ruleset_id']} successfully deleted"
     except CommandExecutionError:
         ret = {}
         ret["result"] = False
@@ -2093,7 +2092,7 @@ def update_ruleset(profile="github", **kwargs):
     action = _format_action(rule_id=True, **params)
 
     if not isinstance(params["ruleset_params"], dict):
-        raise TypeError("params need to be a dict")
+        raise CommandExecutionError("params need to be a dict")
 
     ruleset_params = salt.utils.json.dumps(params["ruleset_params"])
     ret = _query(
@@ -2143,11 +2142,11 @@ def add_ruleset(profile="github", **kwargs):
     action = _format_action(**params)
 
     if not isinstance(params["ruleset_params"], dict):
-        raise TypeError("params need to be a dict")
+        raise CommandExecutionError("params need to be a dict")
     if "name" not in params["ruleset_params"]:
-        raise ValueError("name is required")
+        raise CommandExecutionError("name is required")
     if "enforcement" not in params["ruleset_params"]:
-        raise ValueError("enforcement is required")
+        raise CommandExecutionError("enforcement is required")
 
     ruleset_params = salt.utils.json.dumps(params["ruleset_params"])
     try:

--- a/src/saltext/github/modules/github.py
+++ b/src/saltext/github/modules/github.py
@@ -1826,7 +1826,7 @@ def _query(
 
     log.debug("GitHub URL: %s", url)
 
-    if not header_dict:
+    if header_dict is None:
         header_dict = {}
 
     if not header_dict.get("Authorization"):
@@ -1936,6 +1936,10 @@ def _check_ruleset_params(profile, rule_id=False, rule_params=False, **kwargs):
         try:
             kwargs["header_dict"] = _get_config_value(profile, "header_dict")
         except CommandExecutionError:
+            kwargs["header_dict"] = {}
+
+        # verify header_dict is a dict
+        if not isinstance(kwargs["header_dict"], dict):
             kwargs["header_dict"] = {}
 
     # if ruleset is required, check for ruleset_id

--- a/src/saltext/github/modules/github.py
+++ b/src/saltext/github/modules/github.py
@@ -1830,7 +1830,7 @@ def _query(
         header_dict = {}
 
     if not header_dict.get("Authorization"):
-        header_dict["Authorization"] = f"token {_get_config_value(profile, 'token')}"
+        header_dict["Authorization"] = f"Bearer {_get_config_value(profile, 'token')}"
     if per_page and "per_page" not in args.keys():
         args["per_page"] = per_page
 

--- a/src/saltext/github/modules/github.py
+++ b/src/saltext/github/modules/github.py
@@ -28,10 +28,10 @@ For example:
       # in an automated way. set this to True to allow privacy modifications
       allow_repo_privacy_changes: False
 """
-import json
 import logging
 
 import salt.utils.http
+import salt.utils.json
 from salt.exceptions import CommandExecutionError
 
 HAS_LIBS = False
@@ -2096,7 +2096,7 @@ def update_ruleset(profile="github", **kwargs):
     if not isinstance(params["ruleset_params"], dict):
         raise TypeError("params need to be a dict")
 
-    ruleset_params = json.dumps(params["ruleset_params"])
+    ruleset_params = salt.utils.json.dumps(params["ruleset_params"])
     ret = _query(
         profile, action, method="PUT", data=ruleset_params, header_dict=params["header_dict"]
     )
@@ -2150,7 +2150,7 @@ def add_ruleset(profile="github", **kwargs):
     if "enforcement" not in params["ruleset_params"]:
         raise ValueError("enforcement is required")
 
-    ruleset_params = json.dumps(params["ruleset_params"])
+    ruleset_params = salt.utils.json.dumps(params["ruleset_params"])
     try:
         ret = _query(
             profile, action, method="POST", data=ruleset_params, header_dict=params["header_dict"]

--- a/src/saltext/github/modules/github.py
+++ b/src/saltext/github/modules/github.py
@@ -1863,11 +1863,9 @@ def _query(
             hide_fields=None,
             opts=__opts__,
         )
-        log.debug("GitHub Response Status Code: %s", result["status"])
+        log.debug("GitHub Response Status Code: %s", result.get("status"))
 
-        if result["status"] in [200, 201, 204]:
-            if result["status"] == 204:
-                return result
+        if result.get("status") in [200, 201]:
 
             if isinstance(result["dict"], dict):
                 # If only querying for one item, such as a single issue
@@ -1880,7 +1878,9 @@ def _query(
             ret["dict"] = complete_result
 
         else:
-            return result
+            if result:
+                return result
+            raise CommandExecutionError
 
         try:
             link_info = result.get("headers").get("Link").split(",")[0]
@@ -2075,10 +2075,10 @@ def update_ruleset(profile="github", **kwargs):
         raise CommandExecutionError("params need to be a dict")
 
     ruleset_params = salt.utils.json.dumps(params["ruleset_params"])
-    ret = _query(
-        profile, action, method="PUT", data=ruleset_params, header_dict=params["header_dict"]
-    )
     try:
+        ret = _query(
+            profile, action, method="PUT", data=ruleset_params, header_dict=params["header_dict"]
+        )
         if not ret.get("error"):
             return ret["dict"]
         else:

--- a/src/saltext/github/modules/github.py
+++ b/src/saltext/github/modules/github.py
@@ -123,8 +123,6 @@ def _get_repos(profile, params=None, ignore_cache=False):
         client = _get_client(profile)
         organization = client.get_organization(org_name)
 
-        print("Client: ", client)
-
         result = github.PaginatedList.PaginatedList(
             github.Repository.Repository,
             organization._requester,

--- a/src/saltext/github/modules/github.py
+++ b/src/saltext/github/modules/github.py
@@ -344,10 +344,10 @@ def get_issue(issue_number, repo_name=None, profile="github", output="min"):
     ret = {}
     issue_data = _query(profile, action=action, command=command)
 
-    issue_id = issue_data.get("dict").get("id")
+    issue_id = issue_data.get("dict", {}).get("id")
 
     if issue_id:
-        if output == "full":
+        if output.lower() == "full":
             ret[issue_id] = issue_data["dict"]
         else:
             ret[issue_id] = _format_issue(issue_data["dict"])
@@ -402,7 +402,7 @@ def get_issue_comments(issue_number, repo_name=None, profile="github", since=Non
     comments = _query(profile, action=action, command=command, args=args)
 
     ret = {}
-    for comment in comments.get("dict"):
+    for comment in comments.get("dict", {}):
         comment_id = comment.get("id")
         if output == "full":
             ret[comment_id] = comment
@@ -535,7 +535,7 @@ def get_issues(
     ret = {}
     issues = _query(profile, action=action, command="issues", args=args)
 
-    for issue in issues.get("dict"):
+    for issue in issues.get("dict", {}):
         # Pull requests are included in the issue list from GitHub
         # Let's not include those in the return.
         if issue.get("pull_request"):
@@ -620,7 +620,7 @@ def get_milestones(
     ret = {}
     milestones = _query(profile, action=action, command="milestones", args=args)
 
-    for milestone in milestones.get("dict"):
+    for milestone in milestones.get("dict", {}):
         milestone_id = milestone.get("id")
         if output == "full":
             ret[milestone_id] = milestone
@@ -680,10 +680,10 @@ def get_milestone(number=None, name=None, repo_name=None, profile="github", outp
     if number:
         command = "milestones/" + str(number)
         milestone_data = _query(profile, action=action, command=command)
-        milestone_data = milestone_data.get("dict")
+        milestone_data = milestone_data.get("dict", {})
         milestone_id = milestone_data.get("id")
         if milestone_id:
-            if output == "full":
+            if output.lower() == "full":
                 ret[milestone_id] = milestone_data
             else:
                 milestone_data.pop("creator")
@@ -1733,7 +1733,7 @@ def get_prs(
     ret = {}
     prs = _query(profile, action=action, command="pulls", args=args)
 
-    for pr_ in prs.get("dict"):
+    for pr_ in prs.get("dict", {}):
         pr_id = pr_.get("id")
         if output == "full":
             ret[pr_id] = pr_
@@ -1744,7 +1744,6 @@ def get_prs(
 
 
 def _format_pr(pr_):
-
     """
     Helper function to format API return information into a more manageable
     and useful dictionary for pull request information.

--- a/src/saltext/github/states/github.py
+++ b/src/saltext/github/states/github.py
@@ -798,8 +798,8 @@ def ruleset_absent(
 
                 if result:
                     ret["comment"] = f"Deleted ruleset {name}"
-                    ret["changes"].setdefault("old", f"ruleset {name} exists")
-                    ret["changes"].setdefault("new", f"ruleset {name} deleted")
+                    ret["changes"]["old"] = f"ruleset {name} exists"
+                    ret["changes"]["new"] = f"ruleset {name} deleted"
                     ret["result"] = True
                     return ret
                 else:
@@ -853,7 +853,9 @@ def ruleset_present(
     ret = {"name": name, "changes": {}, "result": True, "comment": ""}
 
     if ruleset_type not in ["org", "repo"]:
-        raise CommandExecutionError
+        ret["result"] = False
+        ret["comment"] = "ruleset_type not set to repo or org"
+        return ret
 
     if ruleset_type == "repo":
         kwargs.update({"owner": owner, "repo_name": repo_name, "ruleset_type": ruleset_type})
@@ -876,7 +878,7 @@ def ruleset_present(
                     for key in ruleset_info and ruleset_params:
                         if ruleset_info.get(key) != ruleset_params.get(key):
                             changes = {
-                                "old": f"Rulset properties were {ruleset_info}",
+                                "old": f"Ruleset properties were {ruleset_info}",
                                 "new": f"Ruleset properties (that changed) are {ruleset_params}",
                             }
                             ret["changes"] = changes

--- a/tests/unit/modules/test_github.py
+++ b/tests/unit/modules/test_github.py
@@ -1,13 +1,224 @@
+from unittest import mock
+from unittest import TestCase
+
 import pytest
+import salt.modules.config as config_module
 import salt.modules.test as testmod
 import saltext.github.modules.github as github_module
+from salt.exceptions import CommandExecutionError
 
 
 @pytest.fixture
 def configure_loader_modules():
     module_globals = {
-        "__salt__": {"test.echo": testmod.echo},
+        "__salt__": {"test.echo": testmod.echo, "config.option": config_module.option},
+        "__opts__": {"mock": {"ruleset_type": "mocked_value"}},
     }
     return {
         github_module: module_globals,
+        config_module: module_globals,
     }
+
+
+@pytest.fixture
+def params():
+    return {
+        "ruleset_type": "repo",
+        "owner": "mock_owner",
+        "repo_name": "mock_repo_name",
+        "org_name": "mock_org_name",
+        "header_dict": {"Authorization": "mock_token"},
+    }
+
+
+def test__check_params():
+    ## test no valid config
+    with TestCase().assertRaises(CommandExecutionError):
+        github_module._check_params(profile="mock")
+
+    # test cli config
+    kwargs = {"ruleset_type": "repo", "repo_name": "mock", "org_name": None}
+    ret = github_module._check_params(profile="mock", **kwargs)
+    assert ret == {"ruleset_type": "repo", "repo_name": "mock"}
+
+
+def test__param_dict():
+    expected = {
+        "ruleset_type": None,
+        "owner": None,
+        "repo_name": None,
+        "org_name": None,
+        "header_dict": None,
+    }
+    assert github_module._param_dict() == expected
+
+
+def test__format_action():
+    kwargs = {"ruleset_type": "repo", "owner": "mock_owner", "repo_name": "mock_repo_name"}
+    expected = "repos/mock_owner/mock_repo_name/rulesets"
+
+    assert github_module._format_action(profile="mock", **kwargs) == expected
+
+
+def test_get_ruleset(params):
+    params["ruleset_id"] = 1
+
+    # test mock 200 status
+    mock_query = {"dict": {"id": "1"}, "status": 200}
+    expected = {"id": "1"}
+
+    with mock.patch("salt.utils.http.query", return_value=mock_query):
+        assert github_module.get_ruleset(profile="mock", **params) == expected
+
+    # test mock 404 error
+    mock_query = {"error": "404 not found", "status": 404}
+    expected = {
+        "comment": "GitHub Response Status Code: 404 not found",
+        "error": "404 not found",
+        "status": 404,
+        "result": False,
+    }
+
+    with mock.patch("salt.utils.http.query", return_value=mock_query):
+        assert github_module.get_ruleset(profile="mock", **params) == expected
+
+    # test mock empty return
+    expected = {"comment": "error getting ruleset", "result": False}
+
+    with mock.patch("salt.utils.http.query", mock.MagicMock(return_value={})):
+        with TestCase().assertRaises((CommandExecutionError, KeyError)):
+            assert github_module.get_ruleset(profile="mock", **params) == expected
+
+
+def test_add_ruleset(params):
+    params["ruleset_params"] = {"name": "mock_name", "enforcement": "disabled"}
+
+    # test mock 201 status
+    mock_query = {"dict": {"name": "mock_name", "enforcement": "disabled"}, "status": 201}
+
+    expected = {"name": "mock_name", "enforcement": "disabled"}
+
+    with mock.patch("salt.utils.http.query", return_value=mock_query):
+        assert github_module.add_ruleset(profile="mock", **params) == expected
+
+    # test mock 404 error
+    expected = {
+        "comment": "GitHub Response Status Code: 404 not found",
+        "error": "404 not found",
+        "status": 404,
+        "result": False,
+    }
+
+    with mock.patch(
+        "salt.utils.http.query", return_value={"error": "404 not found", "status": 404}
+    ):
+        assert github_module.add_ruleset(profile="mock", **params) == expected
+
+    # test mock empty return
+    expected = {"comment": "error getting ruleset", "result": False}
+
+    with mock.patch("salt.utils.http.query", return_value={}):
+        with TestCase().assertRaises((CommandExecutionError, KeyError)):
+            assert github_module.add_ruleset(profile="mock", **params) == expected
+
+
+def test_list_rulesets(params):
+
+    # test mock 200 status
+    mock_query = {
+        "dict": [{"name": "mock_ruleset_1"}, {"name": "mock_ruleset_2"}],
+        "status": 200,
+    }
+
+    expected = [{"name": "mock_ruleset_1"}, {"name": "mock_ruleset_2"}]
+
+    with mock.patch("salt.utils.http.query", return_value=mock_query):
+        assert github_module.list_rulesets(profile="mock", **params) == expected
+
+    # test mock 200 status, no rulesets returned
+    mock_query = {"dict": [], "status": 200}
+    expected = None
+
+    with mock.patch("salt.utils.http.query", return_value=mock_query):
+        assert github_module.list_rulesets(profile="mock", **params) == expected
+
+    # test mock 404 error
+    mock_query = {"error": "404 not found", "status": 404}
+    expected = {
+        "comment": "GitHub Response Status Code: 404 not found",
+        "error": "404 not found",
+        "status": 404,
+        "result": False,
+    }
+
+    with mock.patch("salt.utils.http.query", return_value=mock_query):
+        assert github_module.list_rulesets(profile="mock", **params) == expected
+
+    # test mock empty return
+    expected = {"comment": "error getting ruleset", "result": False}
+
+    with mock.patch("salt.utils.http.query", return_value={}):
+        with TestCase().assertRaises((CommandExecutionError, KeyError)):
+            assert github_module.list_rulesets(profile="mock", **params) == expected
+
+
+def test_update_ruleset(params):
+    params["ruleset_params"] = {"name": "mock_name", "enforcement": "disabled"}
+    params["ruleset_id"] = 1
+
+    # test mock 200 status
+    mock_query = {"dict": {"name": "mock_name", "enforcement": "disabled"}, "status": 200}
+
+    expected = {"name": "mock_name", "enforcement": "disabled"}
+
+    with mock.patch("salt.utils.http.query", return_value=mock_query):
+        assert github_module.update_ruleset(profile="mock", **params) == expected
+
+    # test mock 404 error
+    mock_query = {"error": "404 not found", "status": 404}
+    expected = {
+        "comment": "GitHub Response Status Code: 404 not found",
+        "error": "404 not found",
+        "status": 404,
+        "result": False,
+    }
+
+    with mock.patch("salt.utils.http.query", return_value=mock_query):
+        assert github_module.update_ruleset(profile="mock", **params) == expected
+
+    # test mock empty return
+    expected = {"comment": "error getting ruleset", "result": False}
+
+    with mock.patch("salt.utils.http.query", return_value={}):
+        with TestCase().assertRaises((CommandExecutionError, KeyError)):
+            assert github_module.update_ruleset(profile="mock", **params) == expected
+
+
+def test_delete_ruleset(params):
+    params["ruleset_id"] = 1
+
+    # test mock 204 status
+    mock_query = {"status": 204}
+    expected = {"comment": "ruleset 1 successfully deleted", "status": 204}
+
+    with mock.patch("salt.utils.http.query", return_value=mock_query):
+        assert github_module.delete_ruleset(profile="mock", **params) == expected
+
+    # test mock 404 error
+    mock_query = {"error": "404 not found", "status": 404}
+    expected = {
+        "comment": "GitHub Response Status Code: 404 not found",
+        "error": "404 not found",
+        "status": 404,
+        "result": False,
+    }
+
+    with mock.patch("salt.utils.http.query", return_value=mock_query):
+        assert github_module.delete_ruleset(profile="mock", **params) == expected
+
+    # test mock empty return
+    expected = {"comment": "error getting ruleset", "result": False}
+
+    with mock.patch("salt.utils.http.query", return_value={}):
+        with TestCase().assertRaises((CommandExecutionError, KeyError)):
+            assert github_module.delete_ruleset(profile="mock", **params) == expected

--- a/tests/unit/modules/test_github.py
+++ b/tests/unit/modules/test_github.py
@@ -1,9 +1,7 @@
 from unittest import mock
-from unittest import TestCase
 
 import pytest
 import salt.modules.config as config_module
-import salt.modules.test as testmod
 import saltext.github.modules.github as github_module
 from salt.exceptions import CommandExecutionError
 
@@ -11,8 +9,8 @@ from salt.exceptions import CommandExecutionError
 @pytest.fixture
 def configure_loader_modules():
     module_globals = {
-        "__salt__": {"test.echo": testmod.echo, "config.option": config_module.option},
-        "__opts__": {"mock": {"ruleset_type": "mocked_value"}},
+        "__salt__": {"config.option": config_module.option},
+        "__opts__": {"test_ruleset": {"ruleset_type": "mocked_value"}},
     }
     return {
         github_module: module_globals,
@@ -31,33 +29,23 @@ def params():
     }
 
 
-def test__check_params():
+def test__check_ruleset_params():
     ## test no valid config
-    with TestCase().assertRaises(CommandExecutionError):
-        github_module._check_params(profile="mock")
+    with pytest.raises(CommandExecutionError):
+        github_module._check_ruleset_params(profile="test_ruleset")
 
     # test cli config
-    kwargs = {"ruleset_type": "repo", "repo_name": "mock", "org_name": None}
-    ret = github_module._check_params(profile="mock", **kwargs)
-    assert ret == {"ruleset_type": "repo", "repo_name": "mock"}
-
-
-def test__param_dict():
-    expected = {
-        "ruleset_type": None,
-        "owner": None,
-        "repo_name": None,
-        "org_name": None,
-        "header_dict": None,
-    }
-    assert github_module._param_dict() == expected
-
-
-def test__format_action():
-    kwargs = {"ruleset_type": "repo", "owner": "mock_owner", "repo_name": "mock_repo_name"}
-    expected = "repos/mock_owner/mock_repo_name/rulesets"
-
-    assert github_module._format_action(profile="mock", **kwargs) == expected
+    kwargs = {"ruleset_type": "repo", "repo_name": "mock_repo_name", "owner": "mock_owner"}
+    ret = github_module._check_ruleset_params(profile="test_ruleset", **kwargs)
+    assert ret == (
+        {
+            "ruleset_type": "repo",
+            "repo_name": "mock_repo_name",
+            "owner": "mock_owner",
+            "header_dict": {},
+        },
+        "repos/mock_owner/mock_repo_name/rulesets",
+    )
 
 
 def test_get_ruleset(params):
@@ -68,7 +56,7 @@ def test_get_ruleset(params):
     expected = {"id": "1"}
 
     with mock.patch("salt.utils.http.query", return_value=mock_query):
-        assert github_module.get_ruleset(profile="mock", **params) == expected
+        assert github_module.get_ruleset(profile="test_ruleset", **params) == expected
 
     # test mock 404 error
     mock_query = {"error": "404 not found", "status": 404}
@@ -80,14 +68,12 @@ def test_get_ruleset(params):
     }
 
     with mock.patch("salt.utils.http.query", return_value=mock_query):
-        assert github_module.get_ruleset(profile="mock", **params) == expected
+        assert github_module.get_ruleset(profile="test_ruleset", **params) == expected
 
     # test mock empty return
-    expected = {"comment": "error getting ruleset", "result": False}
-
-    with mock.patch("salt.utils.http.query", mock.MagicMock(return_value={})):
-        with TestCase().assertRaises((CommandExecutionError, KeyError)):
-            assert github_module.get_ruleset(profile="mock", **params) == expected
+    expected = {"comment": "Error getting ruleset", "result": False}
+    with mock.patch("salt.utils.http.query", return_value={}):
+        assert github_module.get_ruleset(profile="test_ruleset", **params) == expected
 
 
 def test_add_ruleset(params):
@@ -99,7 +85,7 @@ def test_add_ruleset(params):
     expected = {"name": "mock_name", "enforcement": "disabled"}
 
     with mock.patch("salt.utils.http.query", return_value=mock_query):
-        assert github_module.add_ruleset(profile="mock", **params) == expected
+        assert github_module.add_ruleset(profile="test_ruleset", **params) == expected
 
     # test mock 404 error
     expected = {
@@ -112,14 +98,13 @@ def test_add_ruleset(params):
     with mock.patch(
         "salt.utils.http.query", return_value={"error": "404 not found", "status": 404}
     ):
-        assert github_module.add_ruleset(profile="mock", **params) == expected
+        assert github_module.add_ruleset(profile="test_ruleset", **params) == expected
 
     # test mock empty return
-    expected = {"comment": "error getting ruleset", "result": False}
+    expected = {"comment": "Error adding ruleset", "result": False}
 
     with mock.patch("salt.utils.http.query", return_value={}):
-        with TestCase().assertRaises((CommandExecutionError, KeyError)):
-            assert github_module.add_ruleset(profile="mock", **params) == expected
+        assert github_module.add_ruleset(profile="test_ruleset", **params) == expected
 
 
 def test_list_rulesets(params):
@@ -133,14 +118,14 @@ def test_list_rulesets(params):
     expected = [{"name": "mock_ruleset_1"}, {"name": "mock_ruleset_2"}]
 
     with mock.patch("salt.utils.http.query", return_value=mock_query):
-        assert github_module.list_rulesets(profile="mock", **params) == expected
+        assert github_module.list_rulesets(profile="test_ruleset", **params) == expected
 
     # test mock 200 status, no rulesets returned
     mock_query = {"dict": [], "status": 200}
     expected = None
 
     with mock.patch("salt.utils.http.query", return_value=mock_query):
-        assert github_module.list_rulesets(profile="mock", **params) == expected
+        assert github_module.list_rulesets(profile="test_ruleset", **params) == expected
 
     # test mock 404 error
     mock_query = {"error": "404 not found", "status": 404}
@@ -152,14 +137,12 @@ def test_list_rulesets(params):
     }
 
     with mock.patch("salt.utils.http.query", return_value=mock_query):
-        assert github_module.list_rulesets(profile="mock", **params) == expected
+        assert github_module.list_rulesets(profile="test_ruleset", **params) == expected
 
     # test mock empty return
-    expected = {"comment": "error getting ruleset", "result": False}
-
+    expected = {"comment": "Error getting rulesets", "result": False}
     with mock.patch("salt.utils.http.query", return_value={}):
-        with TestCase().assertRaises((CommandExecutionError, KeyError)):
-            assert github_module.list_rulesets(profile="mock", **params) == expected
+        assert github_module.list_rulesets(profile="test_ruleset", **params) == expected
 
 
 def test_update_ruleset(params):
@@ -172,7 +155,7 @@ def test_update_ruleset(params):
     expected = {"name": "mock_name", "enforcement": "disabled"}
 
     with mock.patch("salt.utils.http.query", return_value=mock_query):
-        assert github_module.update_ruleset(profile="mock", **params) == expected
+        assert github_module.update_ruleset(profile="test_ruleset", **params) == expected
 
     # test mock 404 error
     mock_query = {"error": "404 not found", "status": 404}
@@ -184,14 +167,12 @@ def test_update_ruleset(params):
     }
 
     with mock.patch("salt.utils.http.query", return_value=mock_query):
-        assert github_module.update_ruleset(profile="mock", **params) == expected
+        assert github_module.update_ruleset(profile="test_ruleset", **params) == expected
 
     # test mock empty return
-    expected = {"comment": "error getting ruleset", "result": False}
-
+    expected = {"comment": "Error updating ruleset", "result": False}
     with mock.patch("salt.utils.http.query", return_value={}):
-        with TestCase().assertRaises((CommandExecutionError, KeyError)):
-            assert github_module.update_ruleset(profile="mock", **params) == expected
+        assert github_module.update_ruleset(profile="test_ruleset", **params) == expected
 
 
 def test_delete_ruleset(params):
@@ -202,7 +183,7 @@ def test_delete_ruleset(params):
     expected = {"comment": "ruleset 1 successfully deleted", "status": 204}
 
     with mock.patch("salt.utils.http.query", return_value=mock_query):
-        assert github_module.delete_ruleset(profile="mock", **params) == expected
+        assert github_module.delete_ruleset(profile="test_ruleset", **params) == expected
 
     # test mock 404 error
     mock_query = {"error": "404 not found", "status": 404}
@@ -214,11 +195,9 @@ def test_delete_ruleset(params):
     }
 
     with mock.patch("salt.utils.http.query", return_value=mock_query):
-        assert github_module.delete_ruleset(profile="mock", **params) == expected
+        assert github_module.delete_ruleset(profile="test_ruleset", **params) == expected
 
     # test mock empty return
-    expected = {"comment": "error getting ruleset", "result": False}
-
+    expected = {"comment": "Error deleting ruleset", "result": False}
     with mock.patch("salt.utils.http.query", return_value={}):
-        with TestCase().assertRaises((CommandExecutionError, KeyError)):
-            assert github_module.delete_ruleset(profile="mock", **params) == expected
+        assert github_module.delete_ruleset(profile="test_ruleset", **params) == expected

--- a/tests/unit/modules/test_github.py
+++ b/tests/unit/modules/test_github.py
@@ -115,14 +115,14 @@ def test_list_rulesets(params):
         "status": 200,
     }
 
-    expected = [{"name": "mock_ruleset_1"}, {"name": "mock_ruleset_2"}]
+    expected = {"rulesets": [{"name": "mock_ruleset_1"}, {"name": "mock_ruleset_2"}]}
 
     with mock.patch("salt.utils.http.query", return_value=mock_query):
         assert github_module.list_rulesets(profile="test_ruleset", **params) == expected
 
     # test mock 200 status, no rulesets returned
     mock_query = {"dict": [], "status": 200}
-    expected = None
+    expected = {"rulesets": None}
 
     with mock.patch("salt.utils.http.query", return_value=mock_query):
         assert github_module.list_rulesets(profile="test_ruleset", **params) == expected

--- a/tests/unit/states/test_github.py
+++ b/tests/unit/states/test_github.py
@@ -1,4 +1,7 @@
+from unittest import mock
+
 import pytest
+import salt.modules.config as config_module
 import salt.modules.test as testmod
 import saltext.github.modules.github as github_module
 import saltext.github.states.github as github_state
@@ -8,25 +11,278 @@ import saltext.github.states.github as github_state
 def configure_loader_modules():
     return {
         github_module: {
-            "__salt__": {
-                "test.echo": testmod.echo,
-            },
+            "__salt__": {"test.echo": testmod.echo, "config.option": config_module.option},
         },
         github_state: {
             "__salt__": {
-                # "github.example_function": github_module.example_function,
+                "github.list_rulesets": mock.MagicMock(return_value=None),
+                "github.delete_ruleset": mock.MagicMock(return_value=None),
+                "github.get_ruleset": mock.MagicMock(return_value=None),
+                "github.update_ruleset": mock.MagicMock(return_value=None),
+                "github.add_ruleset": mock.MagicMock(return_value=None),
             },
+            "__opts__": {"test": False},
+        },
+        config_module: {
+            "__salt__": {"test.echo": testmod.echo, "config.option": config_module.option},
+            "__opts__": {"mock": {"ruleset_type": "mocked_value"}},
         },
     }
 
 
-def test_replace_this_this_with_something_meaningful():
-    echo_str = "Echoed!"
+def test_repo_absent_no_changes():
+    # test list rulesets are None
     expected = {
-        "name": echo_str,
+        "name": "mock_repo_absent",
         "changes": {},
         "result": True,
-        "comment": f"The 'github.example_function' returned: '{echo_str}'",
+        "comment": "Ruleset mock_repo_absent does not exist",
     }
-    # assert github_state.exampled(echo_str) == expected
-    assert True
+
+    ret = github_state.ruleset_absent(
+        name="mock_repo_absent",
+        ruleset_type="repo",
+        profile="mock",
+        owner="mock",
+        repo_name="mock_repo",
+    )
+    assert ret == expected
+
+    # test list rulesets are returned but ruleset to be deleted is not listed
+    mock_query = mock.MagicMock(return_value=[{"name": "mocked_repo_absent"}])
+
+    with mock.patch.dict(github_state.__salt__, {"github.list_rulesets": mock_query}):
+        ret = github_state.ruleset_absent(
+            name="mock_repo_absent",
+            ruleset_type="repo",
+            profile="mock",
+            owner="mock",
+            repo_name="mock_repo",
+        )
+    assert ret == expected
+
+    # test mode
+    expected["result"] = None
+
+    with mock.patch.dict(github_state.__opts__, {"test": True}):
+        ret = github_state.ruleset_absent(
+            name="mock_repo_absent",
+            ruleset_type="repo",
+            profile="mock",
+            owner="mock",
+            repo_name="mock_repo",
+        )
+        assert ret == expected
+
+
+def test_repo_absent_changes():
+
+    expected = {
+        "name": "mock_repo_absent",
+        "changes": {
+            "old": "ruleset mock_repo_absent exists",
+            "new": "ruleset mock_repo_absent deleted",
+        },
+        "result": True,
+        "comment": "Deleted ruleset mock_repo_absent",
+    }
+
+    mock_query = mock.MagicMock(return_value=[{"name": "mock_repo_absent", "id": 1}])
+    mock_delete = mock.MagicMock(return_value={"comment": "ruleset 1 successfully deleted"})
+
+    with mock.patch.dict(
+        github_state.__salt__,
+        {"github.list_rulesets": mock_query, "github.delete_ruleset": mock_delete},
+    ):
+        ret = github_state.ruleset_absent(
+            name="mock_repo_absent",
+            ruleset_type="repo",
+            profile="mock",
+            owner="mock",
+            repo_name="mock_repo",
+        )
+        assert ret == expected
+
+    # test mode
+    expected = {
+        "name": "mock_repo_absent",
+        "changes": {},
+        "result": None,
+        "comment": "Ruleset mock_repo_absent will be deleted",
+    }
+
+    mock_query = mock.MagicMock(return_value=[{"name": "mock_repo_absent", "id": 1}])
+    mock_delete = mock.MagicMock(return_value={"comment": "ruleset 1 successfully deleted"})
+
+    with mock.patch.dict(github_state.__opts__, {"test": True}):
+        with mock.patch.dict(
+            github_state.__salt__,
+            {"github.list_rulesets": mock_query, "github.delete_ruleset": mock_delete},
+        ):
+            ret = github_state.ruleset_absent(
+                name="mock_repo_absent",
+                ruleset_type="repo",
+                profile="mock",
+                owner="mock",
+                repo_name="mock_repo",
+            )
+            assert ret == expected
+
+
+def test_repo_present_no_changes():
+    # Test mode
+    expected = {
+        "name": "mock_repo_absent",
+        "changes": {},
+        "result": None,
+        "comment": "ruleset present",
+    }
+
+    mock_query = mock.MagicMock(return_value=[{"name": "mock_repo_absent", "id": 1}])
+    mock_ruleset = mock.MagicMock(return_value={"name": "mock_repo_absent", "id": 1})
+
+    with mock.patch.dict(github_state.__opts__, {"test": True}):
+        with mock.patch.dict(
+            github_state.__salt__,
+            {"github.list_rulesets": mock_query, "github.get_ruleset": mock_ruleset},
+        ):
+            ret = github_state.ruleset_present(
+                name="mock_repo_absent",
+                ruleset_type="repo",
+                profile="mock",
+                owner="mock",
+                repo_name="mock_repo",
+                ruleset_params={},
+            )
+            assert ret == expected
+
+    expected["result"] = True
+
+    with mock.patch.dict(
+        github_state.__salt__,
+        {"github.list_rulesets": mock_query, "github.get_ruleset": mock_ruleset},
+    ):
+        ret = github_state.ruleset_present(
+            name="mock_repo_absent",
+            ruleset_type="repo",
+            profile="mock",
+            owner="mock",
+            repo_name="mock_repo",
+            ruleset_params={},
+        )
+        assert ret == expected
+
+
+def test_repo_present_update_ruleset():
+    expected = {
+        "name": "mock_repo_absent",
+        "changes": {
+            "old": "Rulset properties were {'name': 'mock_repo_absent', 'id': 1, 'target': 'branch'}",
+            "new": "Ruleset properties (that changed) are {'target': 'tag', 'name': 'mock_repo_absent'}",
+        },
+        "result": True,
+        "comment": "ruleset updated",
+    }
+
+    mock_query = mock.MagicMock(return_value=[{"name": "mock_repo_absent", "id": 1}])
+    mock_ruleset = mock.MagicMock(
+        return_value={"name": "mock_repo_absent", "id": 1, "target": "branch"}
+    )
+    mock_update = mock.MagicMock(
+        return_value={"name": "mock_repo_absent", "id": 1, "target": "tag"}
+    )
+
+    with mock.patch.dict(
+        github_state.__salt__,
+        {
+            "github.list_rulesets": mock_query,
+            "github.get_ruleset": mock_ruleset,
+            "github.update_ruleset": mock_update,
+        },
+    ):
+        ret = github_state.ruleset_present(
+            name="mock_repo_absent",
+            ruleset_type="repo",
+            profile="mock",
+            owner="mock",
+            repo_name="mock_repo",
+            ruleset_params={"target": "tag"},
+        )
+        assert ret == expected
+
+    # Test mode
+    expected = {
+        "name": "mock_repo_absent",
+        "changes": {
+            "old": "Rulset properties were {'name': 'mock_repo_absent', 'id': 1, 'target': 'branch'}",
+            "new": "Ruleset properties (that changed) are {'target': 'tag', 'name': 'mock_repo_absent'}",
+        },
+        "result": None,
+        "comment": "ruleset will be updated",
+    }
+
+    with mock.patch.dict(
+        github_state.__salt__,
+        {
+            "github.list_rulesets": mock_query,
+            "github.get_ruleset": mock_ruleset,
+            "github.update_ruleset": mock_update,
+        },
+    ):
+        with mock.patch.dict(github_state.__opts__, {"test": True}):
+            ret = github_state.ruleset_present(
+                name="mock_repo_absent",
+                ruleset_type="repo",
+                profile="mock",
+                owner="mock",
+                repo_name="mock_repo",
+                ruleset_params={"target": "tag"},
+            )
+        assert ret == expected
+
+
+def test_repo_present_add_ruleset():
+
+    expected = {
+        "name": "mock_repo_absent",
+        "changes": {"old": "No existing ruleset found", "new": "Ruleset created"},
+        "result": True,
+        "comment": "ruleset added",
+    }
+
+    mock_query = mock.MagicMock(return_value=[])
+    mock_add = mock.MagicMock(
+        return_value={"name": "mock_repo_absent", "id": 1, "enforcement": "disabled"}
+    )
+
+    with mock.patch.dict(
+        github_state.__salt__, {"github.list_rulesets": mock_query, "github.add_ruleset": mock_add}
+    ):
+        ret = github_state.ruleset_present(
+            name="mock_repo_absent",
+            ruleset_type="repo",
+            profile="mock",
+            owner="mock",
+            repo_name="mock_repo",
+            ruleset_params={"enforcement": "disabled"},
+        )
+        assert ret == expected
+
+    # Test mode
+    expected["result"] = None
+    expected["comment"] = "ruleset will be added"
+
+    with mock.patch.dict(github_state.__opts__, {"test": True}):
+        with mock.patch.dict(
+            github_state.__salt__,
+            {"github.list_rulesets": mock_query, "github.add_ruleset": mock_add},
+        ):
+            ret = github_state.ruleset_present(
+                name="mock_repo_absent",
+                ruleset_type="repo",
+                profile="mock",
+                owner="mock",
+                repo_name="mock_repo",
+                ruleset_params={"enforcement": "disabled"},
+            )
+            assert ret == expected

--- a/tests/unit/states/test_github.py
+++ b/tests/unit/states/test_github.py
@@ -2,17 +2,12 @@ from unittest import mock
 
 import pytest
 import salt.modules.config as config_module
-import salt.modules.test as testmod
-import saltext.github.modules.github as github_module
 import saltext.github.states.github as github_state
 
 
 @pytest.fixture
 def configure_loader_modules():
     return {
-        github_module: {
-            "__salt__": {"test.echo": testmod.echo, "config.option": config_module.option},
-        },
         github_state: {
             "__salt__": {
                 "github.list_rulesets": mock.MagicMock(return_value=None),
@@ -24,8 +19,8 @@ def configure_loader_modules():
             "__opts__": {"test": False},
         },
         config_module: {
-            "__salt__": {"test.echo": testmod.echo, "config.option": config_module.option},
-            "__opts__": {"mock": {"ruleset_type": "mocked_value"}},
+            "__salt__": {"config.option": config_module.option},
+            "__opts__": {"test_ruleset": {"ruleset_type": "mocked_value"}},
         },
     }
 
@@ -42,7 +37,7 @@ def test_repo_absent_no_changes():
     ret = github_state.ruleset_absent(
         name="mock_repo_absent",
         ruleset_type="repo",
-        profile="mock",
+        profile="test_ruleset",
         owner="mock",
         repo_name="mock_repo",
     )
@@ -55,7 +50,7 @@ def test_repo_absent_no_changes():
         ret = github_state.ruleset_absent(
             name="mock_repo_absent",
             ruleset_type="repo",
-            profile="mock",
+            profile="test_ruleset",
             owner="mock",
             repo_name="mock_repo",
         )
@@ -68,7 +63,7 @@ def test_repo_absent_no_changes():
         ret = github_state.ruleset_absent(
             name="mock_repo_absent",
             ruleset_type="repo",
-            profile="mock",
+            profile="test_ruleset",
             owner="mock",
             repo_name="mock_repo",
         )
@@ -97,7 +92,7 @@ def test_repo_absent_changes():
         ret = github_state.ruleset_absent(
             name="mock_repo_absent",
             ruleset_type="repo",
-            profile="mock",
+            profile="test_ruleset",
             owner="mock",
             repo_name="mock_repo",
         )
@@ -122,7 +117,7 @@ def test_repo_absent_changes():
             ret = github_state.ruleset_absent(
                 name="mock_repo_absent",
                 ruleset_type="repo",
-                profile="mock",
+                profile="test_ruleset",
                 owner="mock",
                 repo_name="mock_repo",
             )
@@ -149,7 +144,7 @@ def test_repo_present_no_changes():
             ret = github_state.ruleset_present(
                 name="mock_repo_absent",
                 ruleset_type="repo",
-                profile="mock",
+                profile="test_ruleset",
                 owner="mock",
                 repo_name="mock_repo",
                 ruleset_params={},
@@ -165,7 +160,7 @@ def test_repo_present_no_changes():
         ret = github_state.ruleset_present(
             name="mock_repo_absent",
             ruleset_type="repo",
-            profile="mock",
+            profile="test_ruleset",
             owner="mock",
             repo_name="mock_repo",
             ruleset_params={},
@@ -177,7 +172,7 @@ def test_repo_present_update_ruleset():
     expected = {
         "name": "mock_repo_absent",
         "changes": {
-            "old": "Rulset properties were {'name': 'mock_repo_absent', 'id': 1, 'target': 'branch'}",
+            "old": "Ruleset properties were {'name': 'mock_repo_absent', 'id': 1, 'target': 'branch'}",
             "new": "Ruleset properties (that changed) are {'target': 'tag', 'name': 'mock_repo_absent'}",
         },
         "result": True,
@@ -203,7 +198,7 @@ def test_repo_present_update_ruleset():
         ret = github_state.ruleset_present(
             name="mock_repo_absent",
             ruleset_type="repo",
-            profile="mock",
+            profile="test_ruleset",
             owner="mock",
             repo_name="mock_repo",
             ruleset_params={"target": "tag"},
@@ -213,10 +208,7 @@ def test_repo_present_update_ruleset():
     # Test mode
     expected = {
         "name": "mock_repo_absent",
-        "changes": {
-            "old": "Rulset properties were {'name': 'mock_repo_absent', 'id': 1, 'target': 'branch'}",
-            "new": "Ruleset properties (that changed) are {'target': 'tag', 'name': 'mock_repo_absent'}",
-        },
+        "changes": {},
         "result": None,
         "comment": "ruleset will be updated",
     }
@@ -233,7 +225,7 @@ def test_repo_present_update_ruleset():
             ret = github_state.ruleset_present(
                 name="mock_repo_absent",
                 ruleset_type="repo",
-                profile="mock",
+                profile="test_ruleset",
                 owner="mock",
                 repo_name="mock_repo",
                 ruleset_params={"target": "tag"},
@@ -261,7 +253,7 @@ def test_repo_present_add_ruleset():
         ret = github_state.ruleset_present(
             name="mock_repo_absent",
             ruleset_type="repo",
-            profile="mock",
+            profile="test_ruleset",
             owner="mock",
             repo_name="mock_repo",
             ruleset_params={"enforcement": "disabled"},
@@ -271,6 +263,7 @@ def test_repo_present_add_ruleset():
     # Test mode
     expected["result"] = None
     expected["comment"] = "ruleset will be added"
+    expected["changes"] = {}
 
     with mock.patch.dict(github_state.__opts__, {"test": True}):
         with mock.patch.dict(
@@ -280,7 +273,7 @@ def test_repo_present_add_ruleset():
             ret = github_state.ruleset_present(
                 name="mock_repo_absent",
                 ruleset_type="repo",
-                profile="mock",
+                profile="test_ruleset",
                 owner="mock",
                 repo_name="mock_repo",
                 ruleset_params={"enforcement": "disabled"},


### PR DESCRIPTION
### What does this PR do?
Add modules and states for basic ability to read, create, update, and delete rulesets.

### What issues does this PR fix or reference?
Fixes: #11 


### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
